### PR TITLE
Improving post type discovery

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,14 @@ Revision history for Web::Mention
 
 {{$NEXT}}
 
+    - Adding support for RSVP webmention types.
+    
+    - Improving post type discovery, according to a W3C-published
+    algorithm
+    (https://www.w3.org/TR/post-type-discovery/#response-algorithm).
+    This fixes a bug that would mis-type webmentions in source documents
+    containing a mix of marked-up link types.
+
 0.501 2018-05-29T13:32:33Z
 
     - Documentation cleanup.
@@ -22,7 +30,8 @@ Revision history for Web::Mention
 
 0.4 2018-05-10T04:34:13Z
 
-    - Adding support for webmention sending. (Passes all create / update / delete tests on http://webmention.rocks, as of May 9, 2018.)
+    - Adding support for webmention sending. (Passes all create / update
+    / delete tests on http://webmention.rocks, as of May 9, 2018.)
     
     - Tidier construction of author objects.
     

--- a/cpanfile
+++ b/cpanfile
@@ -8,7 +8,7 @@ requires "MooseX::ClassAttribute";
 requires "MooseX::Enumeration";
 requires "MooseX::Types::URI";
 requires "Path::Class::Dir";
-requires "Readonly",
+requires "Readonly";
 requires "String::Truncate";
 requires "Try::Tiny";
 requires "Types::Standard";

--- a/cpanfile
+++ b/cpanfile
@@ -8,6 +8,7 @@ requires "MooseX::ClassAttribute";
 requires "MooseX::Enumeration";
 requires "MooseX::Types::URI";
 requires "Path::Class::Dir";
+requires "Readonly",
 requires "String::Truncate";
 requires "Try::Tiny";
 requires "Types::Standard";

--- a/lib/Web/Mention.pm
+++ b/lib/Web/Mention.pm
@@ -301,7 +301,7 @@ sub _build_type {
     my $item = $self->source_mf2_document->get_first( 'h-entry' );
     return 'mention' unless $item;
 
-    # This order is comes from the W3C Post Type Detection algorithm:
+    # This order comes from the W3C Post Type Detection algorithm:
     # https://www.w3.org/TR/post-type-discovery/#response-algorithm
     # ...except adding 'quotation' as a final allowed type, before
     # defaulting to 'mention'.
@@ -942,7 +942,8 @@ method|"FROM_JSON">.
 =head1 NOTES AND BUGS
 
 This software is B<beta>; its interface continues to develop and remains
-subject to change, but not without some effort at supporting its current API.
+subject to change, but not without some effort at supporting its current
+API.
 
 This library does not, at this time, support L<the proposed "Vouch"
 anti-spam extension for Webmention|https://indieweb.org/Vouch>.

--- a/lib/Web/Mention.pm
+++ b/lib/Web/Mention.pm
@@ -806,7 +806,7 @@ Returns undef if this webmention instance hasn't tried to send itself.
 
  my $rsvp = $wm->rsvp_type;
 
-If this webmention is of L<"type"> C<rsvp>, then this method returns the
+If this webmention is of type C<rsvp> (see L<"type">, below), then this method returns the
 type of RSVP represented. It will be one of:
 
 =over

--- a/lib/Web/Mention.pm
+++ b/lib/Web/Mention.pm
@@ -22,7 +22,7 @@ use Web::Mention::Author;
 
 our $VERSION = '0.6';
 
-Readonly my @VALID_rsvp_typeS => qw(yes no maybe interested);
+Readonly my @VALID_RSVP_TYPES => qw(yes no maybe interested);
 
 has 'source' => (
     isa => Uri,
@@ -382,7 +382,7 @@ sub _build_rsvp_type {
     my $rsvp_type;
     if ( my $item = $self->source_mf2_document->get_first( 'h-entry' ) ) {
         if ( my $rsvp_property = $item->get_property( 'rsvp' ) ) {
-            if ( grep { $_ eq lc $rsvp_property } @VALID_rsvp_typeS ) {
+            if ( grep { $_ eq lc $rsvp_property } @VALID_RSVP_TYPES ) {
                 $rsvp_type = $rsvp_property;
             }
         }

--- a/t/rsvp.t
+++ b/t/rsvp.t
@@ -1,0 +1,24 @@
+use warnings;
+use strict;
+use Test::More;
+use Path::Class;
+use FindBin;
+
+use_ok ("Web::Mention");
+
+my $source_path = "$FindBin::Bin/sources/rsvp.html";
+
+my $source_url = "file://$source_path";
+
+my $html = Path::Class::File->new( $source_path )->slurp;
+
+my @wms = Web::Mention->new_from_html(
+    source => $source_url,
+    html => $html,
+);
+
+is ( scalar @wms, 1, 'Got just one webmention.' );
+is ( $wms[0]->type, 'rsvp', 'It is an RSVP.' );
+is ( $wms[0]->rsvp_type, 'interested', 'It has the expected RSVP value.' );
+
+done_testing();

--- a/t/sources/many_types.html
+++ b/t/sources/many_types.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<head>
+<title>This page contains links with various microformats attached.</title>
+</head>
+<div class="h-entry">
+<p>
+<a href="http://example.com/reply-target" class="u-in-reply-to">A reply.</a>
+</p>
+<a href="http://example.com/mention-target">A generic mention.</a></p>
+<a href="http://example.com/quotation-target" class="u-quotation-of">A quotation.</a></p>
+<a href="http://example.com/like-target" class="u-like-of">A like.</a></p>
+<a href="http://example.com/repost-target" class="u-repost-of">A repost.</a></p>
+<p>
+Hooray!
+</p>
+</div>

--- a/t/sources/rsvp.html
+++ b/t/sources/rsvp.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<head>
+<title>This page contains an RSVP.</title>
+</head>
+<div class="h-entry">
+<p>
+I am <span class="p-rsvp">interested</span> in attending <a href="http://example.com/mention-target" class="u-in-reply-to">this event</a>.
+</p>
+</div>

--- a/t/type.t
+++ b/t/type.t
@@ -1,0 +1,40 @@
+use warnings;
+use strict;
+use Test::More;
+use Path::Class;
+use FindBin;
+
+use_ok ("Web::Mention");
+
+my $source_path = "$FindBin::Bin/sources/many_types.html";
+
+my $source_url = "file://$source_path";
+
+my %type_urls;
+my @types = qw(mention reply like repost quotation);
+
+foreach ( @types ) {
+    $type_urls{$_} = target_url_for_type( $_ );
+}
+
+my $html = Path::Class::File->new( $source_path )->slurp;
+
+
+my @wms = Web::Mention->new_from_html(
+    source => $source_url,
+    html => $html,
+);
+
+for my $type ( @types ) {
+    my @type_wms = grep { $_->type eq $type } @wms;
+    is (scalar @type_wms, 1, "Found exactly one '$type' webmention.");
+    is ($type_wms[0]->target, target_url_for_type( $type ), "That webmention has the expected target URL.");
+}
+
+sub target_url_for_type {
+    my ( $type ) = @_;
+
+    return "http://example.com/$type-target";
+}
+
+done_testing();


### PR DESCRIPTION
This improves the module's post type discovery, adhering to this algorithm: https://www.w3.org/TR/post-type-discovery/#response-algorithm

Implementing that algorithm required adding support for RSVP webmentions, and so this adds that as well.