### PR TITLE
Fix warning on HTTP Link headers without rel=

### DIFF
--- a/lib/Web/Mention.pm
+++ b/lib/Web/Mention.pm
@@ -489,7 +489,8 @@ sub _build_endpoint {
     if ( $response->header( 'Link' ) ) {
         my @header_links = HTTP::Link->parse( $response->header( 'Link' ) . '' );
         foreach (@header_links ) {
-            if ($_->{relation} eq 'webmention') {
+            my $relation = $_->{relation};
+            if ($relation && $relation eq 'webmention') {
                 $endpoint = $_->{iri};
             }
         }

--- a/t/sending.t
+++ b/t/sending.t
@@ -18,6 +18,7 @@ my $html_link_target = "$target/c";
 my $no_endpoint_target = "$target/d";
 my $no_webmention_target = "$target/e";
 my $garbage_target = "$target/f";
+my $http_target_no_rel = "$target/g";
 my $evil_target = "http://localhost/muhuhuhahaha";
 
 set_up_test_useragent();
@@ -138,6 +139,29 @@ note("Invalid target - Provides a garbage non-URL as its endpoint");
         source => $source,
         target => $garbage_target,
     );
+    ok ( ! $wm->send );
+}
+
+note("Invalid target - Returns Link header without relation");
+{
+    Web::Mention->ua->map_response(
+        qr{$http_target_no_rel}, HTTP::Response->new(
+            200,
+            'OK',
+            [
+                'Content-Type' => 'application/x-www-form-urlencoded',
+                'Link' => qq{<$good_webmention_endpoint>}
+            ],
+            'Look in the headers for the endpoint, genius.',
+        )
+    );
+
+
+    my $wm = Web::Mention->new(
+        source => $source,
+        target => $http_target_no_rel,
+    );
+
     ok ( ! $wm->send );
 }
 


### PR DESCRIPTION
Some (misconfigured?) hosts return HTTP Link headers with an URL, but without the
rel=... parameter. These caused Web::Mention to emit the following warning:

Use of uninitialized value in string eq at lib/Web/Mention.pm line 492.