### PR TITLE
Improved JSON serialization (and author handling)

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,15 @@ Revision history for Web::Mention
 
 {{$NEXT}}
 
+0.720 2020-07-19T17:19:09Z
+
+    - Improved methods for translating webmentions to and from JSON,
+    including new `as_json` and `new_from_json` methods. Removing
+    documentation for old and annoying serialization expectations.
+    
+    - The `author` method now always returns an object. (Its fields will
+    be present but empty if a webmention's author is unknown or unset.)
+
 0.712 2020-07-04T20:17:21Z
 
     - Explicitly setting the internal user agent object's User-Agent

--- a/META.json
+++ b/META.json
@@ -47,6 +47,7 @@
             "DateTime::Format::ISO8601" : "0",
             "Encode" : "0",
             "HTTP::Link" : "0",
+            "JSON" : "0",
             "LWP" : "0",
             "LWP::Protocol::https" : "0",
             "List::Util" : "0",
@@ -68,7 +69,6 @@
       },
       "test" : {
          "requires" : {
-            "JSON" : "0",
             "Path::Class::Dir" : "0",
             "Test::Exception" : "0",
             "Test::LWP::UserAgent" : "0",
@@ -89,7 +89,7 @@
          "web" : "https://github.com/jmacdotorg/webmention-perl"
       }
    },
-   "version" : "0.712",
+   "version" : "0.720",
    "x_contributors" : [
       "Jason McIntosh <jmac@jmac.org>",
       "Mohammad S Anwar <mohammad.anwar@yahoo.com>",

--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ Note that (as with all this class's constructors) this method won't
 proceed to actually send the generated webmentions; that step remains
 yours to take. (See ["send"](#send).)
 
+### new\_from\_json
+
+    $wm = Web::Mention->new_from_json( $json );
+
+Returns a new webmention based on the JSON output of ["as\_json"](#as_json).
+
 ### new\_from\_request
 
     $wm = Web::Mention->new_from_request( $request_object );
@@ -149,23 +155,6 @@ example.
 
 Throws an exception if the given argument doesn't meet this requirement,
 or if it does but does not define both required HTTP parameters.
-
-### FROM\_JSON
-
-    use JSON;
-
-    $wm = Web::Mention->FROM_JSON(
-       JSON::decode_json( $serialized_webmention )
-    );
-
-Converts an unblessed hash reference resulting from an earlier
-serialization (via [JSON](https://metacpan.org/pod/JSON)) into a fully fledged Web::Mention object.
-See ["SERIALIZATION"](#serialization).
-
-The all-caps spelling comes from a perhaps-misguided attempt to pair
-well with the TO\_JSON method that [JSON](https://metacpan.org/pod/JSON) requires. As such, this method
-may end up deprecated in favor of a less convoluted approach in future
-releases of this module.
 
 ### content\_truncation\_marker
 
@@ -187,13 +176,24 @@ Defaults to 280.
 
 ## Object Methods
 
+### as\_json
+
+    $json = $wm->as_json;
+
+Returns a JSON representation of the webmention.
+
+See ["SERIALIZATION"](#serialization), below, for more information.
+
 ### author
 
     $author = $wm->author;
 
-A Web::Mention::Author object representing the author of this
-webmention's source document, if we're able to determine it. If not,
-this returns undef.
+A [Web::Mention::Author](https://metacpan.org/pod/Web::Mention::Author) object representing the author of this
+webmention's source document. You can get information about the author through
+its `name`, `url`, and `photo` methods.
+
+If the webmention's author is unknown or unset, then this method returns a
+[Web::Mention::Author](https://metacpan.org/pod/Web::Mention::Author) object with all its fields set to `undef`.
 
 ### content
 
@@ -409,17 +409,19 @@ See also ["is\_verified"](#is_verified).
 
 # SERIALIZATION
 
-To serialize a Web::Mention object into JSON, enable [the JSON module's
-"convert\_blessed" feature](https://metacpan.org/pod/JSON#convert_blessed), and then use one of
-that module's JSON-encoding functions on this object. This will result
-in a JSON string containing all the pertinent information about the
-webmention, including its verification status, any content and metadata
-fetched from the target, and so on.
+To serialize a Web::Mention object, use ["as\_json"](#as_json), which returns a
+JSON string that you can store in any way you wish. You can later
+"inflate" it into a Web::Mention object through the ["new\_from\_json"](#new_from_json)
+class method.
 
-To unserialize a Web::Mention object serialized in this way, first
-decode it into an unblessed hash reference via [JSON](https://metacpan.org/pod/JSON), and then pass
-that as the single argument to [the FROM\_JSON class
-method](#from_json).
+Note that a verified webmention might serialize to a significantly
+larger JSON string than an unverified one: it might include a complete
+copy of the source document, its parsed microformats (if any), author
+information, and various other metadata. Unverified webmentions, on the
+other hand, will likely contain little data other that their source and
+target URLs.
+
+This is all normal; verified webmentions just have more luggage.
 
 # NOTES AND BUGS
 

--- a/cpanfile
+++ b/cpanfile
@@ -2,6 +2,7 @@ requires "DateTime";
 requires "DateTime::Format::ISO8601";
 requires "Encode";
 requires "HTTP::Link";
+requires "JSON";
 requires "LWP";
 requires "LWP::Protocol::https";
 requires "Mojo::DOM58";
@@ -26,6 +27,5 @@ on 'test' => sub {
     requires "Test::LWP::UserAgent";
     requires "Test::Warn";
 
-    requires "JSON";
     requires "Path::Class::Dir";
 };

--- a/lib/Web/Mention.pm
+++ b/lib/Web/Mention.pm
@@ -21,7 +21,7 @@ use DateTime::Format::ISO8601;
 use Web::Microformats2::Parser;
 use Web::Mention::Author;
 
-our $VERSION = '0.712';
+our $VERSION = '0.720';
 
 Readonly my @VALID_RSVP_TYPES => qw(yes no maybe interested);
 
@@ -99,7 +99,7 @@ has 'rsvp_type' => (
 );
 
 has 'author' => (
-    isa => Maybe[InstanceOf['Web::Mention::Author']],
+    isa => InstanceOf['Web::Mention::Author'],
     is => 'lazy',
     clearer => '_clear_author',
 );
@@ -304,7 +304,7 @@ sub _build_author {
         );
     }
     else {
-        return;
+        return Web::Mention::Author->new;
     }
 }
 

--- a/lib/Web/Mention.pm
+++ b/lib/Web/Mention.pm
@@ -17,6 +17,7 @@ use URI::Escape;
 use Encode qw(decode_utf8);
 use Readonly;
 use DateTime::Format::ISO8601;
+use JSON;
 
 use Web::Microformats2::Parser;
 use Web::Mention::Author;
@@ -559,6 +560,16 @@ sub _title_element_content {
     }
 }
 
+sub as_json {
+    my $self = shift;
+    return JSON->new->convert_blessed->encode( $self );
+}
+
+sub new_from_json {
+    my ($class, $json) = @_;
+    return $class->FROM_JSON( JSON->new->decode( $json ) );
+}
+
 # Called by the JSON module during JSON encoding.
 # Contrary to the (required) name, returns an unblessed reference, not JSON.
 # See https://metacpan.org/pod/JSON#OBJECT-SERIALISATION
@@ -571,12 +582,14 @@ sub TO_JSON {
         time_received => $self->time_received->epoch,
     };
 
-    if ( $self->is_tested ) {
-    	$return_ref->{ is_tested } = $self->is_tested;
-    	$return_ref->{ is_verified } = $self->is_verified;
-	    $return_ref->{ type } = $self->type;
+   if ( $self->is_tested ) {
+        foreach (qw(
+            is_tested is_verified type content source_html title content
+            rsvp_type
+        )) {
+            $return_ref->{$_} = $self->$_;
+        }
     	$return_ref->{ time_verified } = $self->time_verified->epoch;
-    	$return_ref->{ content } = $self->content;
     	$return_ref->{ source_html } = $self->source_html;
 	    if ( $self->source_mf2_document ) {
     	    $return_ref->{ mf2_document_json } =
@@ -585,6 +598,9 @@ sub TO_JSON {
     	else {
 	        $return_ref->{ mf2_document_json } = undef;
     	}
+        foreach (qw( name url photo ) ) {
+            $return_ref->{ author }->{ $_ } = $self->author->$_;
+        }
     }
 
     return $return_ref;
@@ -601,6 +617,11 @@ sub FROM_JSON {
     	    $data_ref->{ $_ } =
     	        DateTime->from_epoch( epoch => $data_ref->{ $_ } );
     	}
+    }
+
+    if ( $data_ref->{ author } ) {
+        $data_ref->{ author } =
+            Web::Mention::Author->new( $data_ref->{ author } );
     }
 
     my $webmention = $class->new( $data_ref );
@@ -755,6 +776,12 @@ Note that (as with all this class's constructors) this method won't
 proceed to actually send the generated webmentions; that step remains
 yours to take. (See L<"send">.)
 
+=head3 new_from_json
+
+ $wm = Web::Mention->new_from_json( $json );
+
+Returns a new webmention based on the JSON output of L<"as_json">.
+
 =head3 new_from_request
 
  $wm = Web::Mention->new_from_request( $request_object );
@@ -770,23 +797,6 @@ example.
 
 Throws an exception if the given argument doesn't meet this requirement,
 or if it does but does not define both required HTTP parameters.
-
-=head3 FROM_JSON
-
- use JSON;
-
- $wm = Web::Mention->FROM_JSON(
-    JSON::decode_json( $serialized_webmention )
- );
-
-Converts an unblessed hash reference resulting from an earlier
-serialization (via L<JSON>) into a fully fledged Web::Mention object.
-See L<"SERIALIZATION">.
-
-The all-caps spelling comes from a perhaps-misguided attempt to pair
-well with the TO_JSON method that L<JSON> requires. As such, this method
-may end up deprecated in favor of a less convoluted approach in future
-releases of this module.
 
 =head3 content_truncation_marker
 
@@ -808,13 +818,24 @@ Defaults to 280.
 
 =head2 Object Methods
 
+=head3 as_json
+
+ $json = $wm->as_json;
+
+Returns a JSON representation of the webmention.
+
+See L<"SERIALIZATION">, below, for more information.
+
 =head3 author
 
  $author = $wm->author;
 
-A Web::Mention::Author object representing the author of this
-webmention's source document, if we're able to determine it. If not,
-this returns undef.
+A L<Web::Mention::Author> object representing the author of this
+webmention's source document. You can get information about the author through
+its C<name>, C<url>, and C<photo> methods.
+
+If the webmention's author is unknown or unset, then this method returns a
+L<Web::Mention::Author> object with all its fields set to C<undef>.
 
 =head3 content
 
@@ -1066,17 +1087,19 @@ See also L<"is_verified">.
 
 =head1 SERIALIZATION
 
-To serialize a Web::Mention object into JSON, enable L<the JSON module's
-"convert_blessed" feature|JSON/"convert_blessed">, and then use one of
-that module's JSON-encoding functions on this object. This will result
-in a JSON string containing all the pertinent information about the
-webmention, including its verification status, any content and metadata
-fetched from the target, and so on.
+To serialize a Web::Mention object, use L<"as_json">, which returns a
+JSON string that you can store in any way you wish. You can later
+"inflate" it into a Web::Mention object through the L<"new_from_json">
+class method.
 
-To unserialize a Web::Mention object serialized in this way, first
-decode it into an unblessed hash reference via L<JSON>, and then pass
-that as the single argument to L<the FROM_JSON class
-method|"FROM_JSON">.
+Note that a verified webmention might serialize to a significantly
+larger JSON string than an unverified one: it might include a complete
+copy of the source document, its parsed microformats (if any), author
+information, and various other metadata. Unverified webmentions, on the
+other hand, will likely contain little data other that their source and
+target URLs.
+
+This is all normal; verified webmentions just have more luggage.
 
 =head1 NOTES AND BUGS
 

--- a/lib/Web/Mention/Author.pm
+++ b/lib/Web/Mention/Author.pm
@@ -52,7 +52,7 @@ sub new_from_mf2_document {
 
     # "If no h-entry, then there's no post to find authorship for, abort."
     unless ( $h_entry ) {
-        return;
+        return $class->new;
     }
 
     # "If the h-entry has an author property, use that."
@@ -132,7 +132,7 @@ sub new_from_mf2_document {
 
     }
 
-    return;
+    return $class->new;
 
 }
 

--- a/lib/Web/Mention/Author.pm
+++ b/lib/Web/Mention/Author.pm
@@ -2,7 +2,7 @@ package Web::Mention::Author;
 
 use Moo;
 use MooX::ClassAttribute;
-use Types::Standard qw(InstanceOf Str);
+use Types::Standard qw(InstanceOf Str Maybe);
 use Try::Tiny;
 use LWP::UserAgent;
 use List::Util qw(first);
@@ -12,18 +12,18 @@ use Web::Microformats2::Parser;
 
 has 'name' => (
     is => 'ro',
-    isa => Str,
+    isa => Maybe[Str],
 );
 
 has 'url' => (
     is => 'ro',
-    isa => InstanceOf['URI'],
+    isa => Maybe[InstanceOf['URI']],
     coerce => sub { URI->new($_[0]) },
 );
 
 has 'photo' => (
     is => 'ro',
-    isa => InstanceOf['URI'],
+    isa => Maybe[InstanceOf['URI']],
     coerce => sub { URI->new($_[0]) },
 );
 

--- a/t/author.t
+++ b/t/author.t
@@ -31,9 +31,11 @@ sub handle_file {
         local $TODO = "We don't support the "
                       . $file->basename
                       . ' test yet.';
-        no warnings; # Even though this is TODO it still throws undef-warns :/
-        TODO: { ok( $author && $author->name eq 'John Doe' ) }
-        use warnings;
+
+        TODO: {
+            no warnings; # Even though this is TODO, it still throws warns...
+            ok( $author && $author->name eq 'John Doe' );
+        }
     }
     else {
         ok( $author && $author->name eq 'John Doe' );

--- a/t/author.t
+++ b/t/author.t
@@ -31,8 +31,9 @@ sub handle_file {
         local $TODO = "We don't support the "
                       . $file->basename
                       . ' test yet.';
-
+        no warnings; # Even though this is TODO it still throws undef-warns :/
         TODO: { ok( $author && $author->name eq 'John Doe' ) }
+        use warnings;
     }
     else {
         ok( $author && $author->name eq 'John Doe' );

--- a/t/authorship_test_cases/h-entry_with_p-author_h-card.html
+++ b/t/authorship_test_cases/h-entry_with_p-author_h-card.html
@@ -14,7 +14,7 @@
 	</a>
 	<p class="p-name">John Doe</p>
 			</div>
-			<div class="p-name p-summary e-content">Hello World!</div>
+			<div class="p-name p-summary e-content">Hello World! Enjoy <a href="http://example.com/webmention-target">a hyperlink to our webmention test-target</a>.</div>
 		</div>
 
 	</body>

--- a/t/serialization.t
+++ b/t/serialization.t
@@ -9,6 +9,8 @@ use_ok ("Web::Mention");
 my $source = 'file://' . "$FindBin::Bin/sources/content_property.html";
 my $target = "http://example.com/webmention-target";
 
+# Test serialization using JSON methods manually
+{
 my $wm = Web::Mention->new(
     source => $source,
     target => $target,
@@ -24,11 +26,43 @@ my $serialized_wm = $json->encode($wm);
 my $unserialized_wm = Web::Mention->FROM_JSON( $json->decode($serialized_wm) );
 
 is ($unserialized_wm->source, $source,
-    'Unserialized webmention remembers its source.',
+    'Manually unserialized webmention remembers its source.',
 );
 
 ok ($unserialized_wm->is_tested,
-    'Unserialized webmention remembers its is_tested status.',
+    'Manually unserialized webmention remembers its is_tested status.',
 );
+}
+
+# Test serialization using the library's own JSON methods
+{
+my $wm = Web::Mention->new(
+    source => $source,
+    target => $target,
+);
+my $serialized_wm = $wm->as_json;
+my $unserialized_wm = Web::Mention->new_from_json( $serialized_wm );
+
+is ($unserialized_wm->source, $source,
+    'Unserialized, untested webmention remembers its source.',
+);
+ok (not($unserialized_wm->is_tested),
+    'Unserialized, untested webmention remembers its is_tested status.',
+);
+
+$wm->verify;
+
+$serialized_wm = $wm->as_json;
+$unserialized_wm = Web::Mention->new_from_json( $serialized_wm );
+
+is ($unserialized_wm->source, $source,
+    'Unserialized, verified webmention remembers its source.',
+);
+
+ok ($unserialized_wm->is_tested,
+    'Unserialized, verified webmention remembers its is_tested status.',
+);
+
+}
 
 done_testing();

--- a/t/webmention.t
+++ b/t/webmention.t
@@ -10,6 +10,7 @@ my $valid_source = 'file://' . "$FindBin::Bin/sources/valid.html";
 my $escaped_source = 'file://' . "$FindBin::Bin/sources/escaped.html";
 my $invalid_source = 'file://' . "$FindBin::Bin/sources/invalid.html";
 my $nonexistent_source = 'file://' . "$FindBin::Bin/sources/nothing-here.html";
+my $authored_source = 'file://' . "$FindBin::Bin/authorship_test_cases/h-entry_with_p-author_h-card.html";
 
 my $target = "http://example.com/webmention-target";
 
@@ -72,6 +73,24 @@ is ( scalar @webmentions, 2, "Extracted correct number of outgoing webmentions f
 is ( $webmentions[0]->source, $source, "Source looks good.");
 is ( $webmentions[0]->target, $target, "First target looks good.");
 is ( $webmentions[1]->target, 'http://example.com/some-other-target', "Second target looks good.");
+
+my $authored_wm = Web::Mention->new(
+    source => $authored_source,
+    target => $target,
+);
+
+ok ($authored_wm->author, 'Authored webmention has an author object.');
+is ($authored_wm->author->name, 'John Doe',
+    'Authored webmention has correct author name.'
+);
+
+is ($valid_wm->author->name, undef,
+    'Webmention with no author info has no author name.'
+);
+
+is ($nonexistent_wm->author->name, undef,
+    'Webmention with no source document has no author name.'
+);
 
 done_testing();
 


### PR DESCRIPTION
This removes the expectation that users manually call JSON-library methods with specific settings in order to serialize/deserialize Web::Mention objects. Instead, it now presents a `as_json` object method and a `new_from_json` constructor.

The previous methods continue to be used internally, but get removed from documentation here.

This pull request also improves the relationship between a webmention object and its contained author: it will *always* have an author object now. If the author is unknown, that author simply has empty fields. No more need to check for the existence of the author object before working with author information.

Fixes #9.